### PR TITLE
feat: Added PDB option.

### DIFF
--- a/charts/component/Chart.yaml
+++ b/charts/component/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/component/templates/pdb.yaml
+++ b/charts/component/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.pdb .Values.pdb.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "component.fullname" . }}
+  labels:
+    {{- include "component.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "component.fullname" . }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+{{- end }}
+


### PR DESCRIPTION
PDB gives teams to specify minAvailable when enabled, which makes sure that specified minimum available pods are available all the time during Node Draining(happens during scheduled openshift upgrades)