### PR TITLE
chore(ci): use action-oc-runner (for ubuntu-24.04 runner)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,6 @@ jobs:
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           commands: |
-            cd ./${{ matrix.repo_name }}/charts/${{ matrix.repo_name }}
+            cd ./charts/${{ matrix.repo_name }}
             helm dependency update
             helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Validate Changes
         shell: bash
         run: |
-          pwd
-          ls -la
-          whoami
           cd ./${{ matrix.repo_name }}/charts/${{ matrix.repo_name }}
           helm dependency update
           helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        repo_name: [ pubcode, onroutebc]
+        repo_name: [ pubcode, onroutebc ]
         include:
           - repo_name: pubcode
             params: --set global.autoscaling=false --set-string global.repository=bcgov/pubcode --set-string global.secrets.powerBIURL="https://anything" --values values.yaml
@@ -37,13 +37,16 @@ jobs:
         run: |
           DESTINATION_REPO=${{ matrix.repo_name }}  node ./helm-service/util/index.js
 
-      - name: Validate Changes
+      - name: Install oc
         uses: bcgov/action-oc-runner@v1.2.3
         with:
-          oc_namespace: ${{ vars.oc_namespace }}
-          oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
-          commands: |
-            cd ./charts/${{ matrix.repo_name }}
-            helm dependency update
-            helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .
+          oc_server: ${{ vars.oc_server }}
+          oc_namespace: ${{ vars.oc_namespace }}
+
+      - name: Validate Changes
+        shell: bash
+        run: |
+          cd ./${{ matrix.repo_name }}/charts/${{ matrix.repo_name }}
+          helm dependency update
+          helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,13 @@ jobs:
             params: --set global.autoscaling=false --set-string global.repository=bcgov/onroutebc  --set-string global.tag=test  --set-string global.license=test --set-string global.zone=helm-test --set-string global.vault.role=vault-abc --values values.yaml
     timeout-minutes: 2
     steps:
+      - name: Install oc
+        uses: bcgov/action-oc-runner@v1.2.3
+        with:
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ vars.oc_server }}
+          oc_namespace: ${{ vars.oc_namespace }}
+
       - uses: actions/checkout@v4
         with:
           path: ./helm-service
@@ -36,13 +43,6 @@ jobs:
       - name: Execute Program
         run: |
           DESTINATION_REPO=${{ matrix.repo_name }}  node ./helm-service/util/index.js
-
-      - name: Install oc
-        uses: bcgov/action-oc-runner@v1.2.3
-        with:
-          oc_token: ${{ secrets.oc_token }}
-          oc_server: ${{ vars.oc_server }}
-          oc_namespace: ${{ vars.oc_namespace }}
 
       - name: Validate Changes
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,12 +36,14 @@ jobs:
       - name: Execute Program
         run: |
           DESTINATION_REPO=${{ matrix.repo_name }}  node ./helm-service/util/index.js
+
       - name: Validate Changes
-        shell: bash
-        run: |
-          oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
-          oc project ${{ vars.OC_NAMESPACE }} # Safeguard!
-          cd ./${{ matrix.repo_name }}/charts/${{ matrix.repo_name }}
-          helm dependency update
-          helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .
-          
+        uses: bcgov/action-oc-runner@v1.2.3
+        with:
+          oc_namespace: ${{ vars.oc_namespace }}
+          oc_server: ${{ vars.oc_server }}
+          oc_token: ${{ secrets.oc_token }}
+          commands: |
+            cd ./${{ matrix.repo_name }}/charts/${{ matrix.repo_name }}
+            helm dependency update
+            helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Validate Changes
         shell: bash
         run: |
+          pwd
+          ls -la
+          whoami
           cd ./${{ matrix.repo_name }}/charts/${{ matrix.repo_name }}
           helm dependency update
           helm install --dry-run ${{ matrix.repo_name }}-test-helm-update --debug ${{ matrix.params }} .


### PR DESCRIPTION
Runner for ubuntu-24.04 no longer includes oc.  This PR resolves that so we can merge the [relevant Renovate PR](https://github.com/bcgov/helm-service/pull/39).